### PR TITLE
fix: macos x64/arm64构建

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -11,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        os: [ windows-latest, ubuntu-latest, macos-13, macos-14 ]
 
     steps:
     - name: Check out
@@ -30,27 +31,35 @@ jobs:
 
     - name: Build
       run: pyinstaller build.spec
-        
-    - name: Upload (Windows)
-      if: ${{ runner.os == 'windows' }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: SubtitleRenamer_windows
-        path: dist/*.exe
 
-    - name: Upload (macOS)
-      if: ${{ runner.os == 'macos' }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: SubtitleRenamer_mac_x86
-        path: dist/*.app
+    - name: Zip (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd dist
+        7z a -r SubtitleRenamer_windows.zip *
 
-    - name: Upload (Linux)
-      if: ${{ runner.os == 'linux' }}
+    - name: Zip (macOS-x64)
+      if: matrix.os == 'macos-13'
+      run: |
+        cd dist
+        zip -9 -r SubtitleRenamer_macos_x64.zip ./*
+
+    - name: Zip (macOS-arm64)
+      if: matrix.os == 'macos-14'
+      run: |
+        cd dist
+        zip -9 -r SubtitleRenamer_macos_arm64.zip ./*
+
+    - name: Zip (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        cd dist
+        zip -9 -r SubtitleRenamer_linux.zip ./*       
+
+    - name: Upload
       uses: actions/upload-artifact@v3
       with:
-        name: SubtitleRenamer_linux
-        path: dist/*
+        path: dist/*.zip
 
   release:
     needs: build
@@ -58,21 +67,14 @@ jobs:
     steps:
       - name: Download
         uses: actions/download-artifact@v3
+        with:
+          path: asset
 
-      - name: Display files
-        run: ls -R
-
-      - name: Move files
+      - name: dist
         run: |
-          cp -r SubtitleRenamer_mac_x86/SubtitleRenamer.app .
-          cp SubtitleRenamer_windows/SubtitleRenamer.exe .
-          cp SubtitleRenamer_linux/SubtitleRenamer .
-
-      - name: ZIP
-        run: |
-          zip -r SubtitleRenamer_mac_x86.zip SubtitleRenamer.app
-          zip SubtitleRenamer_windows.zip SubtitleRenamer.exe
-          zip SubtitleRenamer_linux.zip SubtitleRenamer
+          mkdir dist
+          cp -r asset/artifact/* dist
+          cd dist && ls
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -81,10 +83,7 @@ jobs:
         with:
           tag_name: tag
           draft: true
-          files: |
-            SubtitleRenamer_windows.zip
-            SubtitleRenamer_mac_x86.zip
-            SubtitleRenamer_linux.zip
+          files: dist/*
           name: 🎉
           body: |
             ## 新增

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,13 +42,13 @@ jobs:
       if: matrix.os == 'macos-13'
       run: |
         cd dist
-        zip -9 -r SubtitleRenamer_macos_x64.zip ./*
+        zip -9 -r SubtitleRenamer_macos_x64.zip ./SubtitleRenamer.app
 
     - name: Zip (macOS-arm64)
       if: matrix.os == 'macos-14'
       run: |
         cd dist
-        zip -9 -r SubtitleRenamer_macos_arm64.zip ./*
+        zip -9 -r SubtitleRenamer_macos_arm64.zip ./SubtitleRenamer.app
 
     - name: Zip (Linux)
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
![image](https://github.com/nuthx/subtitle-renamer/assets/65994850/c0c7e677-6aac-4fb1-b9a4-f597ce159d58)
现在macos-latest已经是arm64了，目前的release都是arm64