### PR TITLE
fix: Correctly read & write the config in utf-8 format

### DIFF
--- a/src/module/config.py
+++ b/src/module/config.py
@@ -85,7 +85,7 @@ def checkConfig(config, config_file):
 # 更新配置文件
 def updateConfigFile(config_file):
     config = configparser.ConfigParser()
-    config.read(config_file)
+    config.read(config_file, encoding="utf-8")
 
     # 记录计数器
     open_times = config.get("Counter", "open_times")
@@ -99,7 +99,7 @@ def updateConfigFile(config_file):
 
         # 重新读取配置文件
         config = configparser.ConfigParser()
-        config.read(config_file)
+        config.read(config_file, encoding="utf-8")
 
         # 更新计数器
         config.set("Counter", "open_times", open_times)
@@ -121,11 +121,11 @@ def readConfig():
         initConfig(config_file)
 
     # 更新配置
-    config.read(config_file)
+    config.read(config_file, encoding="utf-8")
     updateConfigFile(config_file)
 
     # 检测合法性（再次读取获得新配置内容）
-    config.read(config_file)
+    config.read(config_file, encoding="utf-8")
     checkConfig(config, config_file)
 
     return config

--- a/src/module/counter.py
+++ b/src/module/counter.py
@@ -2,7 +2,7 @@ def addOpenTimes(config, config_path):
     open_times = int(config.get("Counter", "open_times")) + 1
     config.set("Counter", "open_times", str(open_times))
 
-    with open(config_path[1], "w") as content:
+    with open(config_path[1], "w", encoding="utf-8") as content:
         config.write(content)
 
 
@@ -10,7 +10,7 @@ def addRenameTimes(config, config_path):
     rename_times = int(config.get("Counter", "rename_times")) + 1
     config.set("Counter", "rename_times", str(rename_times))
 
-    with open(config_path[1], "w") as content:
+    with open(config_path[1], "w", encoding="utf-8") as content:
         config.write(content)
 
 
@@ -18,5 +18,5 @@ def addRenameNum(config, config_path, rename_num):
     rename_num = int(config.get("Counter", "rename_num")) + rename_num
     config.set("Counter", "rename_num", str(rename_num))
 
-    with open(config_path[1], "w") as content:
+    with open(config_path[1], "w", encoding="utf-8") as content:
         config.write(content)


### PR DESCRIPTION
在这个 fix 之前，config 并不完全支持 utf-8 内容的读写。比如 [Extension] 如果填入简体中文的话，程序就无法正确地读写 config