### PR TITLE
feat: 添加轻量识别配置 (#59)

### DIFF
--- a/ui/pages/settings-rename.jsx
+++ b/ui/pages/settings-rename.jsx
@@ -73,6 +73,12 @@ export function RenameSetting() {
             onChange={(checked) => saveConfig("subtitle", "detect_language", checked)}
           />
         </SettingsItem>
+        <SettingsItem title="轻量识别" subtitle="优先根据文件名中的 sc/tc/chs/cht 等扩展名识别简繁类型，匹配失败再通过内容进行识别">
+          <Switch
+            checked={config?.subtitle?.lite_detect}
+            onChange={(checked) => saveConfig("subtitle", "lite_detect", checked)}
+          />
+        </SettingsItem>
       </SettingsCard>
 
       <SettingsCard>

--- a/ui/utils/config.js
+++ b/ui/utils/config.js
@@ -15,6 +15,7 @@ const DEFAULT_CONFIG = {
     highlight_ignore_case: false,
     highlight_numbers_only: false,
     detect_language: true,
+    lite_detect: false,
     exclude_video: "",
     exclude_subtitle: "",
     union_extension: "",

--- a/ui/utils/detect.js
+++ b/ui/utils/detect.js
@@ -38,6 +38,19 @@ const ARCHIVE_EXTENSIONS = new Set([
   "zip", "7z", "rar"
 ])
 
+// 常用简繁字幕扩展名
+const SC_EXTENSIONS = new Set([
+  "sc", "chs", "zh-hans",
+  "zh-cn", "cn",
+  "gb", "zh-chs", "zhs",
+  "zho", "chi", "chn", "zh"
+])
+const TC_EXTENSIONS = new Set([
+  "tc", "cht", "zh-hant",
+  "zh-tw", "zh-hk", "tw", "hk",
+  "big5", "zh-cht", "zht"
+])
+
 export async function detectFiles(paths, fileList, archiveList) {
   const config = await getConfig()
   const newFiles = { video: [], sc: [], tc: [] }
@@ -107,7 +120,7 @@ export async function detectFiles(paths, fileList, archiveList) {
         excludedCount++
         return
       }
-      const lang = config?.subtitle?.detect_language ? await detectSubtitleLanguage(path) : "sc"
+      const lang = config?.subtitle?.detect_language ? await detectSubtitleLanguage(path, config) : "sc"
       newFiles[lang].push(path)
     } else {
       filteredCount++
@@ -132,7 +145,22 @@ export async function detectFiles(paths, fileList, archiveList) {
   }
 }
 
-async function detectSubtitleLanguage(path) {
+async function detectSubtitleLanguage(path, config) {
+  // 先通过文件扩展名判断
+  if (config?.subtitle?.lite_detect) {
+    const extensions = await getMiddleExtensions(path)
+
+    for (const ext of extensions) {
+      // 再次以 _ 或 & 字符拆分，匹配双语字幕
+      const tags = ext.toLowerCase().split(/[_&]/)
+
+      for (const tag of tags) {
+        if (SC_EXTENSIONS.has(tag)) return "sc"
+        if (TC_EXTENSIONS.has(tag)) return "tc"
+      }
+    }
+  }
+
   const bytes = await readFile(path)
 
   // 猜测字幕编码，并解码为可读文本
@@ -163,4 +191,14 @@ async function detectSubtitleLanguage(path) {
   if (count > 0) return "sc"
   if (count < 0) return "tc"
   return "sc"
+}
+
+// 获取中间扩展名
+async function getMiddleExtensions(path) {
+  const ext = await extname(path)
+  const name = await basename(path, `.${ext}`)
+  const parts = name.split(".")
+
+  // 去掉文件名
+  return parts.slice(1)
 }


### PR DESCRIPTION
新增「轻量识别」配置，默认关闭。开启后，在拖入字幕文件进行简繁类型识别时，将采用以下策略：

1. 优先从文件扩展名判断简繁类型
2. 如果没有匹配到，再通过内容解析判断

该策略在可以通过文件名判断的情况下，不必读取完整文件，从而减少大文件场景下的解析时间。

Closes #59